### PR TITLE
chore(deps): bump create-typescript-app to 2.7.2

### DIFF
--- a/.github/workflows/accessibility-alt-text-bot.yml
+++ b/.github/workflows/accessibility-alt-text-bot.yml
@@ -1,0 +1,26 @@
+jobs:
+  accessibility_alt_text_bot:
+    if: ${{ !endsWith(github.actor, '[bot]') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: github/accessibility-alt-text-bot@v1.4.0
+
+name: Accessibility Alt Text Bot
+
+on:
+  issue_comment:
+    types:
+      - created
+      - edited
+  issues:
+    types:
+      - edited
+      - opened
+  pull_request:
+    types:
+      - edited
+      - opened
+
+permissions:
+  issues: write
+  pull-requests: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/prepare
+      - run: pnpm build
+      - run: node lib/index.js
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/prepare
+      - run: pnpm lint
+  prettier:
+    name: Prettier
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/prepare
+      - run: pnpm format --list-different
+  type_check:
+    name: Type Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/prepare
+      - run: pnpm tsc
+
+name: CI
+
+on:
+  pull_request: ~
+  push:
+    branches:
+      - main

--- a/.github/workflows/pr-review-requested.yml
+++ b/.github/workflows/pr-review-requested.yml
@@ -1,0 +1,21 @@
+jobs:
+  pr_review_requested:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          labels: "status: waiting for author"
+      - if: failure()
+        run: |
+          echo "Don't worry if the previous step failed."
+          echo "See https://github.com/actions-ecosystem/action-remove-labels/issues/221."
+
+name: PR Review Requested
+
+on:
+  pull_request_target:
+    types:
+      - review_requested
+
+permissions:
+  pull-requests: write

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<h1>Cta Auto Updates</h1>
+<h1 align="center">Cta Auto Updates</h1>
 
 <p align="center">Testing GHA.</p>
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 		"@eslint/js": "9.22.0",
 		"@types/node": "22.13.10",
 		"chai": "^5.2.0",
-		"create-typescript-app": "^2.7.1",
+		"create-typescript-app": "^2.7.2",
 		"eslint": "9.22.0",
 		"husky": "9.1.7",
 		"lint-staged": "15.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,7 @@ importers:
         specifier: ^5.2.0
         version: 5.2.0
       create-typescript-app:
-        specifier: ^2.7.1
+        specifier: ^2.7.2
         version: 2.7.2(bingo-systems@0.5.4)
       eslint:
         specifier: 9.22.0


### PR DESCRIPTION
This PR intentionally looks similar to a Renovate one for bumping the `create-typescript-app` package:

* The branch name starts with `renovate/`
* The title includes `create-typescript-app`

`main` includes an intentional removal of a style from the README.md's h1 and some other workflow files. This PR shows the new _CTA Renovate_ action automatically correcting that. This is to simulate the case of a newer `create-typescript-app` version changing what files it generates for the repository.